### PR TITLE
fix: 早送りしたままEndingに遷移した際に曲も早送りになってしまう問題を修正

### DIFF
--- a/Assets/Scripts/BgmManager.cs
+++ b/Assets/Scripts/BgmManager.cs
@@ -59,13 +59,13 @@ public class BgmManager : MonoBehaviour
         switch ((SceneIndex)buildIndex)
         {
             case SceneIndex.Title:
-                //タイトル
                 audioSource.Stop();
                 break;
 
             case SceneIndex.Ending:
                 audioSource.clip = ending;
                 CountinuPlay();
+                SetPitch(1.0f);
                 break;
 
             default:
@@ -80,17 +80,9 @@ public class BgmManager : MonoBehaviour
     /// BGMの速さを変更する
     /// </summary>
     /// <param name="pitch">速度</param>
-    public void ChangePitch(float pitch = 1.0f)
+    public void SetPitch(float pitch = 1.0f)
     {
         audioSource.pitch = pitch;
-    }
-
-    /// <summary>
-    /// 右クリックした際にBGMも早送りに
-    /// </summary>
-    void Update()
-    {
-        ChangePitch(Time.timeScale);
     }
 
 }

--- a/Assets/Scripts/BgmManager.cs
+++ b/Assets/Scripts/BgmManager.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.SceneManagement;
+using Utility;
 
 /// <summary>
 /// 全ステージのBGMを管理する
@@ -20,9 +21,7 @@ public class BgmManager : MonoBehaviour
         DontDestroyOnLoad(this.gameObject);
     }
 
-
     private AudioSource audioSource;
-
     public AudioClip stage;
     public AudioClip ending;
 
@@ -35,6 +34,12 @@ public class BgmManager : MonoBehaviour
 
         //エディター上でBGMを流すために使用
         PlayBgm(SceneManager.GetActiveScene().buildIndex);
+    }
+
+    //シーンが切り替わった瞬間に呼ばれるメソッド　
+    void OnActiveSceneChanged(Scene prevScene, Scene nextScene)
+    {
+        PlayBgm(nextScene.buildIndex);
     }
 
     /// <summary>
@@ -51,29 +56,24 @@ public class BgmManager : MonoBehaviour
 
     void PlayBgm(int buildIndex)
     {
-        if (buildIndex == (int)Utility.SceneIndex.Title)
+        switch ((SceneIndex)buildIndex)
         {
-            //タイトル
-            audioSource.Stop();
-        }
-        else if (buildIndex == (int)Utility.SceneIndex.Ending)
-        {
-            //エンディング
-            audioSource.clip = ending;
-            CountinuPlay();
-        }
-        else
-        {
-            //ステージ
-            audioSource.clip = stage;
-            CountinuPlay();
-        }
-    }
+            case SceneIndex.Title:
+                //タイトル
+                audioSource.Stop();
+                break;
 
-    //シーンが切り替わった瞬間に呼ばれるメソッド　
-    void OnActiveSceneChanged(Scene prevScene, Scene nextScene)
-    {
-        PlayBgm(nextScene.buildIndex);
+            case SceneIndex.Ending:
+                audioSource.clip = ending;
+                CountinuPlay();
+                break;
+
+            default:
+                //ステージ
+                audioSource.clip = stage;
+                CountinuPlay();
+                break;
+        }
     }
 
     /// <summary>
@@ -84,7 +84,6 @@ public class BgmManager : MonoBehaviour
     {
         audioSource.pitch = pitch;
     }
-
 
     /// <summary>
     /// 右クリックした際にBGMも早送りに

--- a/Assets/Scripts/TimeCtrl.cs
+++ b/Assets/Scripts/TimeCtrl.cs
@@ -8,8 +8,27 @@ public class TimeCtrl : MonoBehaviour
 {
     private const float defaultFastTimeScale = 4.0f;
     private const float defaultTimeScale = 1.0f;
+
+    private BgmManager bgmManager;
+
+    void Start()
+    {
+        // テストシーンなどでBgmManagerが存在しないときに備える
+        try
+        {
+            bgmManager = GameObject.Find("BgmManager").GetComponent<BgmManager>();
+        }
+        catch (System.NullReferenceException e)
+        {
+            bgmManager = null;
+            Debug.Log(e);
+            Debug.Log("BgmManagerが見つかりませんでした");
+        }
+    }
     void Update()
     {
+        // 1 は右クリック
+        // Unity側のKeyCodeで定義がないのでハードコードしている
         FastFoward(Input.GetMouseButton(1));
     }
 
@@ -24,10 +43,13 @@ public class TimeCtrl : MonoBehaviour
         if (toggleFlag)
         {
             Time.timeScale = fastTimeScale;
+            // TODO: null条件演算子はUnityでは非推奨であるため修正する
+            bgmManager?.SetPitch(fastTimeScale);
         }
         else
         {
             Time.timeScale = defaultTimeScale;
+            bgmManager?.SetPitch(defaultTimeScale);
         }
     }
 
@@ -41,6 +63,7 @@ public class TimeCtrl : MonoBehaviour
         if (stopFlag)
         {
             Time.timeScale = 0;
+            bgmManager?.SetPitch(defaultTimeScale);
         }
         else
         {


### PR DESCRIPTION
# 早送りしたままEndingに遷移した際に曲も早送りになってしまう問題を修正

- 従来BgmManager内のUpdateでChangePitchを呼び出していた部分をTimeCtrlで呼び出すように変更
- TimeCtrlでChangePitchを呼び出す際にテストシーンなどではBgmManagerが存在しないので、try-catchでnullを明確に代入し、更にnull条件演算子で回避している